### PR TITLE
Update TileSaver.pde

### DIFF
--- a/02_M/M_3_4_01_TOOL/TileSaver.pde
+++ b/02_M/M_3_4_01_TOOL/TileSaver.pde
@@ -57,6 +57,10 @@ class TileSaver {
     tileFilename=_filename;
     tileNum=_num;
     tileNumSq=(tileNum*tileNum);
+    
+    // Reset tile counters to start over correctly
+    tileX = 0;
+    tileY = 0;
 
     width=p.width;
     height=p.height;


### PR DESCRIPTION
initialize the tile counting values for each run so the second image does not get mixed up, as the values aren't reset correctly after the first run.
